### PR TITLE
Don't 500 on malformed tokens

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
 
+gem install bundler
 bundle update
 env CONJUR_ENV=ci bundle exec rake spec

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
-gem install bundler
-bundle update
-env CONJUR_ENV=ci bundle exec rake spec
+rm -f Gemfile.lock
+
+docker run --rm \
+  -v $PWD:/usr/src/app \
+  -w /usr/src/app \
+  -e CONJUR_ENV=ci \
+  ruby:2.2.4 \
+  sh -c "bundle update && bundle exec rake spec"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+bundle update
+env CONJUR_ENV=ci bundle exec rake spec

--- a/lib/conjur/rack/authenticator.rb
+++ b/lib/conjur/rack/authenticator.rb
@@ -112,9 +112,13 @@ module Conjur
       
       def verify_authorization_and_get_identity
         if http_authorization.to_s[/^Token token="(.*)"/]
-          token = JSON.parse(Base64.decode64($1))
-          account = validate_token_and_get_account(token)
-          return [token, account]
+          begin
+            token = JSON.parse(Base64.decode64($1))
+            account = validate_token_and_get_account(token)
+            return [token, account]
+          rescue JSON::ParserError
+            raise AuthorizationError.new("Malformed authorization token")
+          end
         else
           path = http_path
           if optional_paths.find{|p| p.match(path)}.nil?

--- a/spec/rack/authenticator_spec.rb
+++ b/spec/rack/authenticator_spec.rb
@@ -130,6 +130,20 @@ describe Conjur::Rack::Authenticator do
         expect(call).to eq([401, {"Content-Type"=>"text/plain", "Content-Length"=>"29"}, ["Malformed authorization token"]])
       end
     end
+
+    context "with JSON junk in token" do
+      let(:env) { { 'HTTP_AUTHORIZATION' => 'Token token="eyJmb28iOiAiYmFyIn0="' } }
+      before do
+        slosilo_class = class_double('Slosilo')
+        stub_const('Slosilo', slosilo_class)
+        allow(slosilo_class).to receive(:new).and_return(Module.new)
+        allow(Slosilo).to receive(:token_signer).and_return(nil)
+      end
+
+      it "returns 401" do
+          expect(call).to eq([401, {"Content-Type"=>"text/plain", "Content-Length"=>"27"}, ["Unauthorized: Invalid token"]])
+      end
+    end
   end
   context "to a protected path" do
     context "without authorization" do

--- a/spec/rack/authenticator_spec.rb
+++ b/spec/rack/authenticator_spec.rb
@@ -123,6 +123,13 @@ describe Conjur::Rack::Authenticator do
         end
       end
     end
+
+    context "with junk in token" do
+      let(:env) { { 'HTTP_AUTHORIZATION' => 'Token token="open sesame"' } }
+      it "returns 401" do
+        expect(call).to eq([401, {"Content-Type"=>"text/plain", "Content-Length"=>"29"}, ["Malformed authorization token"]])
+      end
+    end
   end
   context "to a protected path" do
     context "without authorization" do


### PR DESCRIPTION
Makes conjur-rack return 401 on encountering headers like
'Token token="ALL YOUR BASE"'. It used to return 500, which
was annoying and unhelpful.