### PR TITLE
Gracefully ignore unhandled headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# unreleased version
+
+* Ignore headers such as Conjur-Privilege or Conjur-Audit if they're not
+supported by the API (instead of erroring out).
+
 # v3.1.0
 
 * Support for JWT Slosilo tokens.


### PR DESCRIPTION
Conjur v5 API doesn't (currently) support global privileges and audit.
Conjur-rack consumed some headers related to these features, and would
error out if they were present and not supported.

Instead let's silently ignore them in that case (which seems to me to
be the most correct course of action).

(This commit also includes some spec refactoring and adjustments to
make sure it works with conjur5 api library.)